### PR TITLE
Write file.encoding and default.charset to the log file at startup.

### DIFF
--- a/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
+++ b/src/main/java/org/vorthmann/zome/ui/ApplicationUI.java
@@ -358,9 +358,11 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
 				"os.name",
 				"os.arch",
                 "sun.java.command",
+				"file.encoding",
 			}); 
 		appendPropertiesList(sb, loggingProperties(), new String[] 
         {
+            "default.charset",
             "logfile.name",
             "logging.properties.filename",
             "logging.properties.file.exists",
@@ -384,7 +386,6 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
 	}
     
     private static Properties loggingProperties() {
-        Properties props = new Properties();
         File f = new File(".", "logging.properties");
         // Use same logic to locate the file as LogManager.getLogManager().readConfiguration() uses...
         String fname = System.getProperty("java.util.logging.config.file");
@@ -401,6 +402,8 @@ public final class ApplicationUI implements ActionListener, PropertyChangeListen
         } catch (IOException ex) {
             ex.printStackTrace();
         }
+        Properties props = new Properties();
+        props.put("default.charset", java.nio.charset.Charset.defaultCharset().name());
         props.put("logfile.name", getLogFileName());        
         props.put("logging.properties.filename", fname);        
         props.put("logging.properties.file.exists", Boolean.toString(f.exists()));        


### PR DESCRIPTION
Some extended chars such as phi and the square root symbol are not rendered correctly in the Netbeans debugger window or the log files when run in Windows. This is part of an attempt to resolve that issue by evaluating related JRE parameters in other environments like the MAC. I think I may have resolved the NetBeans issue in Windows, but I'll wait to document it until I've done more testing and find out from Scott what these two settings are on his MAC.